### PR TITLE
Enable macros for ftp-copy-action regex field

### DIFF
--- a/src/main/java/io/cdap/action/ftp/FTPActionConfig.java
+++ b/src/main/java/io/cdap/action/ftp/FTPActionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Cask Data, Inc.
+ * Copyright © 2017-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -68,6 +68,7 @@ public abstract class FTPActionConfig extends PluginConfig {
   @Name(FILE_NAME_REGEX)
   @Description("Regex to copy only the file names that match. By default, all files will be copied.")
   @Nullable
+  @Macro
   private final String fileNameRegex;
 
   public FTPActionConfig(String host, Integer port, String userName, String password, String destDirectory,


### PR DESCRIPTION
Enabled macros for the Regex field.