### PR TITLE
Bump develop version to 1.5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,13 @@
   <groupId>io.cdap.plugin</groupId>
   <artifactId>ftp-copy-action</artifactId>
   <packaging>jar</packaging>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.5.0-SNAPSHOT</version>
   <name>ftp-copy-action</name>
   <url>http://maven.apache.org</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.3.0-SNAPSHOT</cdap.version>
     <mock.ftp.version>2.6</mock.ftp.version>
     <junit.version>4.11</junit.version>
   </properties>


### PR DESCRIPTION
Bumped version to 1.5.0-SNAPSHOT and changed CDAP version dependency to 6.3.0-SNAPSHOT.